### PR TITLE
Massive overhaul to allow the library to be used as a npm package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# Node modules are ignored
+
+node_modules

--- a/Framework/jsGFwk.js
+++ b/Framework/jsGFwk.js
@@ -145,3 +145,10 @@ var jsGFwk = (function(){
 		}
 	};
 })();
+
+/**
+ * Adding the module as an export if module.exports is present.
+ */
+if (typeof module !== 'undefined' && module.exports) {
+	module.exports = function () { return require('shallow-copy')(jsGFwk); };
+}

--- a/Framework/jsGFwk2dFastAnimation.js
+++ b/Framework/jsGFwk2dFastAnimation.js
@@ -1,3 +1,11 @@
+/*
+ * Adding the module as an import if module.exports is present.
+ */
+if (typeof module !== 'undefined' && module.exports) {
+	var jsGFwk = {};
+}
+
+
 /** @title: jsGFwk.FastAnimation
  * @description: Recommended plugin implementation for 2D games.<br>This is faster than BasicAnimation plugin.
  * @usage: jsGFwk.include(<b>"FastAnimation"</b>) */
@@ -82,4 +90,12 @@ jsGFwk.FastAnimation = {
 		jsGFwk.include(this._plugInName);
 		if (!this._loaded) { this._loaded = true; this.onStart(); }
 	}
+}
+
+/**
+ * We export it if we enable it only on node.
+ * 
+ */
+if (typeof module !== 'undefined' && module.exports) {
+	module.exports = require('./node-exporter')(jsGFwk);
 }

--- a/Framework/jsGFwkBasicAnimation.js
+++ b/Framework/jsGFwkBasicAnimation.js
@@ -1,3 +1,10 @@
+/*
+ * Adding the module as an import if module.exports is present.
+ */
+if (typeof module !== 'undefined' && module.exports) {
+	var jsGFwk = {};
+}
+
 /** @title: jsGFwk.BasicAnimation
  * @description: Low performance plugin for 2D games.<br>For a better performance see <i>jsGFwk2dFastAnimation</i>.
  * @usage: jsGFwk.include(<b>"BasicAnimation"</b>) */
@@ -57,4 +64,12 @@ jsGFwk.BasicAnimation = {
 		jsGFwk.include(this._plugInName);
 		if (!this._loaded) { this._loaded = true; this.onStart(); }
 	}
+}
+
+/**
+ * We export it if we enable it only on node.
+ * 
+ */
+if (typeof module !== 'undefined' && module.exports) {
+	module.exports = require('./node-exporter')(jsGFwk);
 }

--- a/Framework/jsGFwkCamera.js
+++ b/Framework/jsGFwkCamera.js
@@ -1,3 +1,10 @@
+/*
+ * Adding the module as an import if module.exports is present.
+ */
+if (typeof module !== 'undefined' && module.exports) {
+	var jsGFwk = {};
+}
+
 jsGFwk.Camera = {
 	_plugInName: "Camera",
 	_loaded: false,
@@ -80,4 +87,12 @@ jsGFwk.Camera = {
 		jsGFwk.include(this._plugInName);
 		if (!this._loaded) { this._loaded = true; this.onStart(); }
 	}
+}
+
+/**
+ * We export it if we enable it only on node.
+ * 
+ */
+if (typeof module !== 'undefined' && module.exports) {
+	module.exports = require('./node-exporter')(jsGFwk);
 }

--- a/Framework/jsGFwkCollisions.js
+++ b/Framework/jsGFwkCollisions.js
@@ -1,3 +1,10 @@
+/*
+ * Adding the module as an import if module.exports is present.
+ */
+if (typeof module !== 'undefined' && module.exports) {
+	var jsGFwk = {};
+}
+
 /** @title: jsGFwk.Collisions
  * @description: Simple plugins for collision detections.<br>Box collision and radial collision supported.
  * @usage: jsGFwk.include(<b>"Collisions"</b>) */
@@ -92,3 +99,11 @@ jsGFwk.Collisions = {
 		if (!this._loaded) { this._loaded = true; this.onStart(); }
 	}
 };
+
+/**
+ * We export it if we enable it only on node.
+ * 
+ */
+if (typeof module !== 'undefined' && module.exports) {
+	module.exports = require('./node-exporter')(jsGFwk);
+}

--- a/Framework/jsGFwkContainer.js
+++ b/Framework/jsGFwkContainer.js
@@ -1,3 +1,10 @@
+/*
+ * Adding the module as an import if module.exports is present.
+ */
+if (typeof module !== 'undefined' && module.exports) {
+	var jsGFwk = {};
+}
+
 /** @title: jsGFwk.Container
  * @description: This plugin allows to contain and clone game objects, handling each as part of the same group.
  * @usage: jsGFwk.include(<b>"Container"</b>) */
@@ -110,3 +117,11 @@ jsGFwk.Container = (function() {
 		}
 	};
 })();
+
+/**
+ * We export it if we enable it only on node.
+ * 
+ */
+if (typeof module !== 'undefined' && module.exports) {
+	module.exports = require('./node-exporter')(jsGFwk);
+}

--- a/Framework/jsGFwkDebugger.js
+++ b/Framework/jsGFwkDebugger.js
@@ -1,3 +1,10 @@
+/*
+ * Adding the module as an import if module.exports is present.
+ */
+if (typeof module !== 'undefined' && module.exports) {
+	var jsGFwk = {};
+}
+
 jsGFwk.Debugger = {
 	_plugInName: "Debugger",
 	_loaded: false,
@@ -75,3 +82,11 @@ jsGFwk.Debugger = {
 		if (!this._loaded) { this._loaded = true; this.onStart(); }
 	}
 };
+
+/**
+ * We export it if we enable it only on node.
+ * 
+ */
+if (typeof module !== 'undefined' && module.exports) {
+	module.exports = require('./node-exporter')(jsGFwk);
+}

--- a/Framework/jsGFwkEffects.js
+++ b/Framework/jsGFwkEffects.js
@@ -1,3 +1,10 @@
+/*
+ * Adding the module as an import if module.exports is present.
+ */
+if (typeof module !== 'undefined' && module.exports) {
+	var jsGFwk = {};
+}
+
 jsGFwk.Effects = {
 	_plugInName: "Effects",
 	_loaded: false,
@@ -52,3 +59,11 @@ jsGFwk.Effects = {
 		if (!this._loaded) { this._loaded = true; this.onStart(); }
 	}
 };
+
+/**
+ * We export it if we enable it only on node.
+ * 
+ */
+if (typeof module !== 'undefined' && module.exports) {
+	module.exports = require('./node-exporter')(jsGFwk);
+}

--- a/Framework/jsGFwkFonts.js
+++ b/Framework/jsGFwkFonts.js
@@ -1,3 +1,10 @@
+/*
+ * Adding the module as an import if module.exports is present.
+ */
+if (typeof module !== 'undefined' && module.exports) {
+	var jsGFwk = {};
+}
+
 jsGFwk.Fonts = {
 	_plugInName: "Fonts",
 	_loaded: false,
@@ -37,3 +44,11 @@ jsGFwk.Fonts = {
 		if (!this._loaded) { this._loaded = true; this.onStart(); }
 	}
 };
+
+/**
+ * We export it if we enable it only on node.
+ * 
+ */
+if (typeof module !== 'undefined' && module.exports) {
+	module.exports = require('./node-exporter')(jsGFwk);
+}

--- a/Framework/jsGFwkGamepad.js
+++ b/Framework/jsGFwkGamepad.js
@@ -1,3 +1,10 @@
+/*
+ * Adding the module as an import if module.exports is present.
+ */
+if (typeof module !== 'undefined' && module.exports) {
+	var jsGFwk = {};
+}
+
 jsGFwk.Gamepad = {
 	_plugInName: 'Gamepad',
 	_loaded: false,
@@ -54,4 +61,12 @@ jsGFwk.Gamepad = {
 		jsGFwk.include(this._plugInName);
 		if (!this._loaded) { this._loaded = true; this.onStart(); }
 	}
+}
+
+/**
+ * We export it if we enable it only on node.
+ * 
+ */
+if (typeof module !== 'undefined' && module.exports) {
+	module.exports = require('./node-exporter')(jsGFwk);
 }

--- a/Framework/jsGFwkIO.js
+++ b/Framework/jsGFwkIO.js
@@ -1,3 +1,10 @@
+/*
+ * Adding the module as an import if module.exports is present.
+ */
+if (typeof module !== 'undefined' && module.exports) {
+	var jsGFwk = {};
+}
+
 jsGFwk.IO = {
 	_plugInName: "IO",
 	_loaded: false,
@@ -199,3 +206,11 @@ jsGFwk.IO = {
 		if (!this._loaded) { this._loaded = true; this.onStart(); }
 	}
 };
+
+/**
+ * We export it if we enable it only on node.
+ * 
+ */
+if (typeof module !== 'undefined' && module.exports) {
+	module.exports = require('./node-exporter')(jsGFwk);
+}

--- a/Framework/jsGFwkImages.js
+++ b/Framework/jsGFwkImages.js
@@ -1,6 +1,13 @@
+/*
+ * Adding the module as an import if module.exports is present.
+ */
+if (typeof module !== 'undefined' && module.exports) {
+	var jsGFwk = {};
+}
+
 jsGFwk.Images = {
 	_plugInName: "Images",
-	_loaded: false;
+	_loaded: false,
 	merge: function (fromData, toData, settings) {
 		var tempCanvas = document.createElement("canvas");
 		tempCanvas.width = settings.width;
@@ -36,3 +43,11 @@ jsGFwk.Images = {
 		if (!this._loaded) { this._loaded = true; this.onStart(); }
 	}
 };
+
+/**
+ * We export it if we enable it only on node.
+ * 
+ */
+if (typeof module !== 'undefined' && module.exports) {
+	module.exports = require('./node-exporter')(jsGFwk);
+}

--- a/Framework/jsGFwkJukebox.js
+++ b/Framework/jsGFwkJukebox.js
@@ -1,3 +1,10 @@
+/*
+ * Adding the module as an import if module.exports is present.
+ */
+if (typeof module !== 'undefined' && module.exports) {
+	var jsGFwk = {};
+}
+
 jsGFwk.Jukebox = (function() {
 
 	var juke = function (settings) {
@@ -58,3 +65,11 @@ jsGFwk.Jukebox = (function() {
 	
 	return juke;
 })();
+
+/**
+ * We export it if we enable it only on node.
+ * 
+ */
+if (typeof module !== 'undefined' && module.exports) {
+	module.exports = require('./node-exporter')(jsGFwk);
+}

--- a/Framework/jsGFwkPath.js
+++ b/Framework/jsGFwkPath.js
@@ -1,3 +1,10 @@
+/*
+ * Adding the module as an import if module.exports is present.
+ */
+if (typeof module !== 'undefined' && module.exports) {
+	var jsGFwk = {};
+}
+
 jsGFwk.Path = {
 	
 	_plugInName: "Path",
@@ -47,4 +54,12 @@ jsGFwk.Path = {
 		jsGFwk.include(this._plugInName);
 		if (!this._loaded) { this._loaded = true; this.onStart(); }
 	}
+}
+
+/**
+ * We export it if we enable it only on node.
+ * 
+ */
+if (typeof module !== 'undefined' && module.exports) {
+	module.exports = require('./node-exporter')(jsGFwk);
 }

--- a/Framework/jsGFwkRM.js
+++ b/Framework/jsGFwkRM.js
@@ -1,3 +1,10 @@
+/*
+ * Adding the module as an import if module.exports is present.
+ */
+if (typeof module !== 'undefined' && module.exports) {
+	var jsGFwk = {};
+}
+
 jsGFwk.ResourceManager = {
 		_plugInName: "ResourceManager",
 		_loaded: false,
@@ -115,3 +122,11 @@ jsGFwk.ResourceManager = {
 			if (!this._loaded) { this._loaded = true; this.onStart(); }
 		}
 };
+
+/**
+ * We export it if we enable it only on node.
+ * 
+ */
+if (typeof module !== 'undefined' && module.exports) {
+	module.exports = require('./node-exporter')(jsGFwk);
+}

--- a/Framework/jsGFwkScenes.js
+++ b/Framework/jsGFwkScenes.js
@@ -1,3 +1,10 @@
+/*
+ * Adding the module as an import if module.exports is present.
+ */
+if (typeof module !== 'undefined' && module.exports) {
+	var jsGFwk = {};
+}
+
 jsGFwk.Scenes = (function() {
 
 	var _currentScene;
@@ -45,3 +52,11 @@ jsGFwk.Scenes = (function() {
 		}
 	};
 })();
+
+/**
+ * We export it if we enable it only on node.
+ * 
+ */
+if (typeof module !== 'undefined' && module.exports) {
+	module.exports = require('./node-exporter')(jsGFwk);
+}

--- a/Framework/jsGFwkSprites.js
+++ b/Framework/jsGFwkSprites.js
@@ -1,3 +1,10 @@
+/*
+ * Adding the module as an import if module.exports is present.
+ */
+if (typeof module !== 'undefined' && module.exports) {
+	var jsGFwk = {};
+}
+
 jsGFwk.Sprites = {
 
 	_loaded: false,
@@ -295,3 +302,11 @@ jsGFwk.Sprites = {
 		if (!this._loaded) { this._loaded = true; this.onStart(); }
 	}
 };
+
+/**
+ * We export it if we enable it only on node.
+ * 
+ */
+if (typeof module !== 'undefined' && module.exports) {
+	module.exports = require('./node-exporter')(jsGFwk);
+}

--- a/Framework/jsGFwkTimers.js
+++ b/Framework/jsGFwkTimers.js
@@ -1,3 +1,10 @@
+/*
+ * Adding the module as an import if module.exports is present.
+ */
+if (typeof module !== 'undefined' && module.exports) {
+	var jsGFwk = {};
+}
+
 jsGFwk.Timer = (function() {
 
 	var timers = function (processor) {
@@ -38,3 +45,11 @@ jsGFwk.Timer = (function() {
 	
 	return timers;
 })();
+
+/**
+ * We export it if we enable it only on node.
+ * 
+ */
+if (typeof module !== 'undefined' && module.exports) {
+	module.exports = require('./node-exporter')(jsGFwk);
+}

--- a/Framework/jsGFwkWebStorage.js
+++ b/Framework/jsGFwkWebStorage.js
@@ -1,3 +1,10 @@
+/*
+ * Adding the module as an import if module.exports is present.
+ */
+if (typeof module !== 'undefined' && module.exports) {
+	var jsGFwk = {};
+}
+
 jsGFwk.Storage = {
 	_plugInName: "Storage",
 	_loaded: false,
@@ -42,4 +49,12 @@ jsGFwk.Storage = {
 		jsGFwk.include(this._plugInName);
 		if (!this._loaded) { this._loaded = true; this.onStart(); }
 	}
+}
+
+/**
+ * We export it if we enable it only on node.
+ * 
+ */
+if (typeof module !== 'undefined' && module.exports) {
+	module.exports = require('./node-exporter')(jsGFwk);
 }

--- a/Framework/node-exporter.js
+++ b/Framework/node-exporter.js
@@ -1,0 +1,18 @@
+// This is a generic way to export the added modules easily.
+// (I am lazy to do it manually everywere)
+
+// It is a function than returns a setup function.
+module.exports = function (exported) {
+
+  // The setup function just copies keys of the exported module into the Framework.
+  return  function (isLoaded, jsGFwk) {
+    // If it's not loaded, we return.
+    if (!isLoaded) return;
+	  var keys = Object.keys(exported);
+	  for (var i = 0; i < keys.length; ++i) {
+      var key = keys[i];
+			jsGFwk[key] = exported[key]; 
+	  }
+  };
+
+};

--- a/Readme.md
+++ b/Readme.md
@@ -1,3 +1,9 @@
+# jsGFwk
+
+A simple framework for game development.
+
+## What's this?
+
 This is a simple minimalistic game framework for JavaScript and HTML5
 
 This framework will allow you to:
@@ -12,3 +18,81 @@ More important:
 - To be used as a foundation for complex games or to work with other frameworks
 
 AND REMEMBER. SIMPLICITY IS THE BEST.
+
+## How to use it in node
+
+First install it: (adding a published package in npm in the future)
+
+```sh
+npm install --save github:MatiasIac/jsGFwk
+```
+
+Then you need to load an instance of the framework.
+
+The framework can be loaded multiple times on node:
+
+Add a file, such as: framework.js in your project:
+
+### ES5: 
+
+```js
+const jsGFwkSetup = require('jsgfwk');
+module.exports = jsGFwkSetup({
+  // Here you can put the modules you want to load,
+  // All are by default loaded, but you can disable one using:
+  fastAnimations: false,
+  // To disable fastAnimations, under this list is a list of plugins.
+})
+```
+
+### ES6:
+
+```js
+import jsGFwkSetup from 'jsgfwk';
+
+export default jsGFwkSetup({
+  // Here you can put the modules you want to load,
+  // All are by default loaded, but you can disable one using:
+  fastAnimations: false,
+  // To disable fastAnimations, under this list is a list of plugins.  
+})
+
+```
+
+## What Plugins are available
+
+| Plugin Name       | Description               | Configuration name |
+| ----------------- | ------------------------- | ------------------ |
+| Basic Animations  |                           |  basicAnimations   |
+| Fast Animations   |                           |  fastAnimations    |
+| Camera            |                           |  camera            |
+| Collisions        |                           |  collisions        |
+| Container         |                           |  container         |
+| Debugger          |                           |  debugger          |
+| Effects           |                           |  effects           |
+| Fonts             |                           |  fonts             |
+| Gamepad           |                           |  gamepad           |
+| Images            |                           |  images            |
+| IO                |                           |  io                |
+| Jukebox           |                           |  jukebox           |
+| Path              |                           |  path              |
+| Resource Manager  |                           |  resourceManager   |
+| Scenes            |                           |  scenes            |
+| Sprites           |                           |  sprites           |
+| Sugar             |Simplifies getters/settes  |  (Not exported)    |
+| Timers            |                           |  timers            |
+| Web Storage       |                           |  webStorage        |
+
+## Testing the framework
+
+First, clone this repository and install dependencies:
+
+```sh 
+npm install
+```
+
+Then just run:
+
+```sh 
+npm run test
+```

--- a/index.js
+++ b/index.js
@@ -1,0 +1,85 @@
+// This is the core framework and our main entry point.
+// This MUST be loaded first.
+var jsGFwkSetup = require ('./Framework/jsGFwk');
+
+// extend works just like jQuery.extend
+var extend = require('extend');
+
+// This is a list of available plugins.
+var fastAnimationPlugin   = require('./Framework/jsGFwk2dFastAnimation');
+var basicAnimationPlugin  = require('./Framework/jsGFwkBasicAnimation');
+var cameraPlugin          = require('./Framework/jsGFwkCamera');
+var collisionsPlugin      = require('./Framework/jsGFwkCollisions');
+var containerPlugin       = require('./Framework/jsGFwkContainer');
+var debuggerPlugin        = require('./Framework/jsGFwkDebugger');
+var effectsPlugin         = require('./Framework/jsGFwkEffects');
+var fontsPlugin           = require('./Framework/jsGFwkFonts');
+var gamepadPlugin         = require('./Framework/jsGFwkGamepad');
+var imagesPlugin          = require('./Framework/jsGFwkImages');
+var ioPlugin              = require('./Framework/jsGFwkIO');
+var jukeboxPlugin         = require('./Framework/jsGFwkJukebox');
+var pathPlugin            = require('./Framework/jsGFwkPath');
+var resourceManagerPlugin = require('./Framework/jsGFwkRM');
+var scenesPlugin          = require('./Framework/jsGFwkScenes');
+var spritesPlugin         = require('./Framework/jsGFwkSprites');
+var timersPlugin          = require('./Framework/jsGFwkTimers');
+var webStoragePlugin      = require('./Framework/jsGFwkWebStorage');
+
+var defaultOptions = {
+  fastAnimation:   true,
+  basicAnimation:  true,
+  camera:          true,
+  collisions:      true,
+  container:       true,
+  debugger:        true,
+  effects:         true,
+  fonts:           true,
+  gamepad:         true,
+  images:          true,
+  io:              true,
+  jukebox:         true,
+  path:            true,
+  resourceManager: true,
+  scenes:          true,
+  sprites:         true,
+  timers:          true,
+  webStorage:      true,
+};
+
+
+// We export our entire module from here.
+module.exports = function (options) {
+
+  if (typeof options === 'undefined') {
+    options = {};
+  }
+
+  // We extend our options with the defaults.
+  var loaded = extend({}, defaultOptions, options);
+
+  var jsGFwk = jsGFwkSetup();
+
+  // We load all modules. In Node, we let things like uglify and webpack to 
+  // optimize wich parts aren't using, so they are removed automatically.
+  fastAnimationPlugin(loaded.fastAnimation, jsGFwk);
+  basicAnimationPlugin(loaded.basicAnimation, jsGFwk);
+  cameraPlugin(loaded.camera, jsGFwk);
+  collisionsPlugin(loaded.collisions, jsGFwk);
+  containerPlugin(loaded.container, jsGFwk);
+  debuggerPlugin(loaded.debugger, jsGFwk);
+  effectsPlugin(loaded.effects, jsGFwk);
+  fontsPlugin(loaded.fonts, jsGFwk);
+  gamepadPlugin(loaded.gamepad, jsGFwk);
+  imagesPlugin(loaded.images, jsGFwk);
+  ioPlugin(loaded.io, jsGFwk);
+  jukeboxPlugin(loaded.jukebox, jsGFwk);
+  pathPlugin(loaded.path, jsGFwk);
+  resourceManagerPlugin(loaded.resourceManager, jsGFwk);
+  scenesPlugin(loaded.scenes, jsGFwk);
+  spritesPlugin(loaded.sprites, jsGFwk);
+  timersPlugin(loaded.timers, jsGFwk);
+  webStoragePlugin(loaded.webStorage, jsGFwk);
+
+  return jsGFwk;
+
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "jsgfwk",
+  "version": "1.0.0",
+  "description": "A simple 2D game framework in JS",
+  "main": "index.js",
+  "directories": {
+    "doc": "docs"
+  },
+  "scripts": {
+    "test": "./node_modules/.bin/mocha --reporter spec"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/MatiasIac/jsGFwk.git"
+  },
+  "keywords": [
+    "js",
+    "game",
+    "2d"
+  ],
+  "author": "Matias Iacono <no@mail.com>",
+  "contributors": [
+    {
+      "name": "Ramiro Rojo",
+      "email": "ramiro.rojo.cretta@gmail.com"
+    }
+  ],
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/MatiasIac/jsGFwk/issues"
+  },
+  "homepage": "https://github.com/MatiasIac/jsGFwk#readme",
+  "devDependencies": {
+    "chai": "^3.5.0",
+    "mocha": "^3.2.0"
+  },
+  "dependencies": {
+    "extend": "^3.0.0",
+    "shallow-copy": "0.0.1"
+  }
+}

--- a/test/node-all-packages.js
+++ b/test/node-all-packages.js
@@ -1,0 +1,90 @@
+const jsGFwk = require ('../index')();
+
+const { expect } = require('chai');
+
+describe('Testing node packages', function() {
+  it('Checks than the core library exists', function () {
+    expect(jsGFwk).to.exist;
+  });
+
+  it('Checks than the Fast Animation library exists', function () {
+    expect(jsGFwk.FastAnimation).to.exist;
+  });
+
+  it('Checks than the Basic Animation library exists', function () {
+    expect(jsGFwk.BasicAnimation).to.exist;
+  });
+
+  it('Checks than the Camera library exists', function () {
+    expect(jsGFwk.Camera).to.exist;
+  });
+
+  it('Checks than the Collisions library exists', function () {
+    expect(jsGFwk.Collisions).to.exist;
+  });
+
+  it('Checks than the Container library exists', function () {
+    expect(jsGFwk.Container).to.exist;
+  });
+
+  it('Checks than the Debugger library exists', function () {
+    expect(jsGFwk.Debugger).to.exist;
+  });
+
+  it('Checks than the Effects library exists', function () {
+    expect(jsGFwk.Effects).to.exist;
+  });
+
+  it('Checks than the Fonts library exists', function () {
+    expect(jsGFwk.Fonts).to.exist;
+  });              
+
+  it('Checks than the Fonts library exists', function () {
+    expect(jsGFwk.Fonts).to.exist;
+  });              
+
+  it('Checks than the Fonts library exists', function () {
+    expect(jsGFwk.Fonts).to.exist;
+  });              
+
+
+  it('Checks than the Gamepad library exists', function () {
+    expect(jsGFwk.Gamepad).to.exist;
+  });              
+
+
+  it('Checks than the Images library exists', function () {
+    expect(jsGFwk.Images).to.exist;
+  });              
+
+
+  it('Checks than the IO library exists', function () {
+    expect(jsGFwk.IO).to.exist;
+  });              
+
+
+  it('Checks than the Jukebox library exists', function () {
+    expect(jsGFwk.Jukebox).to.exist;
+  });              
+
+  it('Checks than the Path library exists', function () {
+    expect(jsGFwk.Path).to.exist;
+  });              
+
+  it('Checks than the Resource Manager library exists', function () {
+    expect(jsGFwk.ResourceManager).to.exist;
+  });              
+
+  it('Checks than the Scenes library exists', function () {
+    expect(jsGFwk.Scenes).to.exist;
+  });              
+  
+  it('Checks than the Timer library exists', function () {
+    expect(jsGFwk.Timer).to.exist;
+  });                 
+
+  it('Checks than the Storage library exists', function () {
+    expect(jsGFwk.Storage).to.exist;
+  });         
+
+});

--- a/test/only-some-packages.js
+++ b/test/only-some-packages.js
@@ -1,0 +1,14 @@
+const jsGFwk = require ('../index')({ fastAnimation: false });
+
+const { expect } = require('chai');
+
+describe('Testing node packages', function() {
+
+  it('Checks than the core library exists', function () {
+    expect(jsGFwk).to.exist;
+  });
+
+  it('Checks than the Fast Animation library was not loaded', function () {
+    expect(jsGFwk.FastAnimation).to.not.exist;
+  });
+})


### PR DESCRIPTION
I was working a bit on it, but now the framework can be used as an NPM package easily.

I also added some more info on README.md, I have to check what each plugin does to fill the descriptions, but this looks nicer.

**Also** I made unit tests using mocha and chai, I made it to test the module exports, but it can be used for more.

We can use this with [Travis CI](https://travis-ci.org/) now, and check than they build, it may not be needed thou, and testing than the game works is better explained at the examples